### PR TITLE
Bind BLOB fix from zombiezen

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -48,8 +48,8 @@ package sqlite
 //
 // // Use a helper function here to avoid the cgo pointer detection
 // // logic treating SQLITE_TRANSIENT as a Go pointer.
-// static int transient_bind_text(sqlite3_stmt* stmt, int col, char* p, int n) {
-//	return sqlite3_bind_text(stmt, col, p, n, SQLITE_TRANSIENT);
+// static int transient_bind_blob(sqlite3_stmt* stmt, int col, unsigned char* p, int n) {
+//	return sqlite3_bind_blob(stmt, col, p, n, SQLITE_TRANSIENT);
 // }
 //
 // extern void log_fn(void* pArg, int code, char* msg);
@@ -775,11 +775,11 @@ func (stmt *Stmt) BindBytes(param int, value []byte) {
 	if stmt.stmt == nil {
 		return
 	}
-	var v *C.char
+	var v *C.uchar
 	if len(value) != 0 {
-		v = (*C.char)(unsafe.Pointer(&value[0]))
+		v = (*C.uchar)(unsafe.Pointer(&value[0]))
 	}
-	res := C.transient_bind_text(stmt.stmt, C.int(param), v, C.int(len(value)))
+	res := C.transient_bind_blob(stmt.stmt, C.int(param), v, C.int(len(value)))
 	runtime.KeepAlive(value)
 	stmt.handleBindErr("BindBytes", res)
 }

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -386,7 +386,7 @@ func TestBindBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stmt = c.Prep("SELECT count(*) FROM bindbytes WHERE c = $bytes;")
+	stmt = c.Prep("SELECT count(*) FROM bindbytes WHERE c = CAST($bytes AS TEXT);")
 	stmt.SetText("$bytes", "column_value")
 	if hasRow, err := stmt.Step(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
See https://github.com/crawshaw/sqlite/pull/95. Since the getlantern fork is being actively used, it will help to include all the relevant fixes we need there. Working around the bug fixed by the bind BLOB fix has performance ramifications, so it's better to just fix it.