### PR TITLE
Set busy timeout && use in-memory temp stores for Android

### DIFF
--- a/sqlite.go
+++ b/sqlite.go
@@ -153,6 +153,10 @@ func openConn(path string, flags ...OpenFlags) (*Conn, error) {
 		}
 	})
 
+	// Large timeout as Go programs should control timeouts
+	// using SetInterrupt. Documented in SetBusyTimeout.
+	conn.SetBusyTimeout(10 * time.Second)
+
 	if openFlags&SQLITE_OPEN_WAL > 0 {
 		stmt, _, err := conn.PrepareTransient("PRAGMA journal_mode=wal;")
 		if err != nil {
@@ -166,9 +170,6 @@ func openConn(path string, flags ...OpenFlags) (*Conn, error) {
 		}
 	}
 
-	// Large timeout as Go programs should control timeouts
-	// using SetInterrupt. Documented in SetBusyTimeout.
-	conn.SetBusyTimeout(10 * time.Second)
 
 	return conn, nil
 }


### PR DESCRIPTION
Related to https://github.com/getlantern/grants/issues/401

This PR does two things:
- merge a very old commit about setting busy timeouts to master
- Add a build flag for using an in-memory temp store for Android (see comment blob in the code for an explanation)